### PR TITLE
Implements #9: New HAL for ATmega32U4

### DIFF
--- a/ardufocus/avr_usart.cpp
+++ b/ardufocus/avr_usart.cpp
@@ -24,14 +24,14 @@ usart::buffer_t usart::buffer;
 ISR(USART_RX_VECT) {
   // read a byte from the incoming stream
   // check for parity error and buffer it
-  if (bit_is_clear(UCSR0A, UPE0)) { usart::buffer.rx.enqueue(UDR0); }
+  if (bit_is_clear(USART_CSRA, USART_BIT_PE)) { usart::buffer.rx.enqueue(USART_DR); }
 }
 
 ISR(USART_TX_VECT) {
   // transmit a byte from the buffer
   // disable USART TX ISR when buffer is empty
   if (! usart::buffer.tx.empty()) {
-    UDR0 = usart::buffer.tx.dequeue();
-    UCSR0A |= bit(TXC0);
-  } else { UCSR0B &= ~bit(UDRIE0); }
+    USART_DR = usart::buffer.tx.dequeue();
+    USART_CSRA |= bit(USART_BIT_TXC);
+  } else { USART_CSRB &= ~bit(USART_BIT_DRIE); }
 }

--- a/ardufocus/avr_usart.h
+++ b/ardufocus/avr_usart.h
@@ -24,19 +24,10 @@
 
 #include "ringbuf.h"
 #include "macro.h"
+#include "hal.h"
 
 #define SERIAL_TXBUF_SZ 39u
 #define SERIAL_RXBUF_SZ 78u
-
-#if defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328PB__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__)
-  #ifdef __AVR_ATmega328PB__
-    #define USART_RX_VECT USART0_RX_vect
-    #define USART_TX_VECT USART0_UDRE_vect
-  #else
-    #define USART_RX_VECT USART_RX_vect
-    #define USART_TX_VECT USART_UDRE_vect
-  #endif
-#endif
 
 namespace usart {
   struct buffer_t {

--- a/ardufocus/hal.h
+++ b/ardufocus/hal.h
@@ -23,48 +23,116 @@
 #include <avr/pgmspace.h>
 #include "macro.h"
 
-enum hal_register_headers_t { HALDIR, HALOUT, HALIN, HALTMR, HALPIN };
-enum hal_non_existent_t     { NOT_A_PIN = 0, NOT_A_PORT = 0 };
+#define hal_tbl_lookup(a, b) pgm_read_word(&pin_map[a][b])
+
+enum hal_register_headers_t { IO_DIR, IO_DATA, IO_IN, IO_BIT };
 
 #if defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328PB__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__)
 
-  enum hal_timer_t { NOTIMER = 0, TIMER0A, TIMER0B, TIMER1A, TIMER1B, TIMER2A, TIMER2B };
+  const uint16_t pin_map[][4] PROGMEM = {
+    // PIN                IO_DIR,           IO_DATA,            IO_IN, IO_BIT
+    /*   0 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(0) },
+    /*   1 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(1) },
+    /*   2 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(2) },
+    /*   3 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(3) },
+    /*   4 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(4) },
+    /*   5 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(5) },
+    /*   6 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(6) },
+    /*   7 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(7) },
 
-  const uint16_t pin_map[][5] PROGMEM = {
-    /* pin,              HALDIR,            HALOUT,            HALIN,   HALTMR, HALPIN */
-    /*  0 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  NOTIMER,  bit(0) },
-    /*  1 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  NOTIMER,  bit(1) },
-    /*  2 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  NOTIMER,  bit(2) },
-    /*  3 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  TIMER2B,  bit(3) },
-    /*  4 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  NOTIMER,  bit(4) },
-    /*  5 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  TIMER0B,  bit(5) },
-    /*  6 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  TIMER0A,  bit(6) },
-    /*  7 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND,  NOTIMER,  bit(7) },
+    /*   8 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(0) },
+    /*   9 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(1) },
+    /*  10 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(2) },
+    /*  11 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(3) },
+    /*  12 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(4) },
+    /*  13 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(5) },
 
-    /*  8 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB,  NOTIMER,  bit(0) },
-    /*  9 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB,  TIMER1A,  bit(1) },
-    /* 10 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB,  TIMER1B,  bit(2) },
-    /* 11 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB,  TIMER2A,  bit(3) },
-    /* 12 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB,  NOTIMER,  bit(4) },
-    /* 13 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB,  NOTIMER,  bit(5) },
-
-    /* 14 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC,  NOTIMER,  bit(0) },
-    /* 15 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC,  NOTIMER,  bit(1) },
-    /* 16 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC,  NOTIMER,  bit(2) },
-    /* 17 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC,  NOTIMER,  bit(3) },
-    /* 18 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC,  NOTIMER,  bit(4) },
-    /* 19 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC,  NOTIMER,  bit(5) },
+    /*  14 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(0) },
+    /*  15 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(1) },
+    /*  16 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(2) },
+    /*  17 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(3) },
+    /*  18 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(4) },
+    /*  19 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(5) },
   };
+
+  #define USART_BRRH UBRR0H // Baud Rate Register High
+  #define USART_BRRL UBRR0L // Baud Rate Register Low
+  #define USART_CSRA UCSR0A // Control and Status Register A
+  #define USART_CSRB UCSR0B // Control and Status Register B
+  #define USART_DR   UDR0   // Data Register
+
+  #define USART_BIT_DRE   UDRE0  // Data Register Empty
+  #define USART_BIT_DRIE  UDRIE0 // Data Register Empty Interrupt Enable
+  #define USART_BIT_PE    UPE0   // Parity Error
+  #define USART_BIT_RXCIE RXCIE0 // Receive Complete Interrupt Enable
+  #define USART_BIT_RXEN  RXEN0  // Receive Enable
+  #define USART_BIT_TXC   TXC0   // Transmit Complete
+  #define USART_BIT_TXEN  TXEN0  // Transmit Enable
+  #define USART_BIT_U2X   U2X0   // Double Speed Operation
 
   #ifdef __AVR_ATmega328PB__
     #define USART_RX_VECT USART0_RX_vect
     #define USART_TX_VECT USART0_UDRE_vect
+
   #else
     #define USART_RX_VECT USART_RX_vect
     #define USART_TX_VECT USART_UDRE_vect
   #endif
 
+#elif defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)
+
+  const uint16_t pin_map[][4] PROGMEM = {
+    // PIN                IO_DIR,           IO_DATA,            IO_IN, IO_BIT
+    /*   0 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(2) },
+    /*   1 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(3) },
+    /*   2 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(1) },
+    /*   3 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(0) },
+    /*   4 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(4) },
+    /*   5 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(6) },
+    /*   6 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(7) },
+    /*   7 */ { (uint16_t) &DDRE, (uint16_t) &PORTE, (uint16_t) &PINE, bit(6) },
+    /*   8 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(4) },
+    /*   9 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(5) },
+    /*  10 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(6) },
+
+    /*  11 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(7) },
+    /*  12 */ { (uint16_t) &DDRD, (uint16_t) &PORTD, (uint16_t) &PIND, bit(6) },
+    /*  13 */ { (uint16_t) &DDRC, (uint16_t) &PORTC, (uint16_t) &PINC, bit(7) },
+
+    /*  14 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(3) },
+    /*  15 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(1) },
+    /*  16 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(2) },
+    /*  17 */ { (uint16_t) &DDRB, (uint16_t) &PORTB, (uint16_t) &PINB, bit(0) },
+
+    /*  18 */ { (uint16_t) &DDRF, (uint16_t) &PORTF, (uint16_t) &PINF, bit(7) },
+    /*  19 */ { (uint16_t) &DDRF, (uint16_t) &PORTF, (uint16_t) &PINF, bit(6) },
+    /*  20 */ { (uint16_t) &DDRF, (uint16_t) &PORTF, (uint16_t) &PINF, bit(5) },
+    /*  21 */ { (uint16_t) &DDRF, (uint16_t) &PORTF, (uint16_t) &PINF, bit(4) },
+    /*  22 */ { (uint16_t) &DDRF, (uint16_t) &PORTF, (uint16_t) &PINF, bit(1) },
+    /*  23 */ { (uint16_t) &DDRF, (uint16_t) &PORTF, (uint16_t) &PINF, bit(0) },
+  };
+
+  #define USART_BRRH UBRR1H // Baud Rate Register High
+  #define USART_BRRL UBRR1L // Baud Rate Register Low
+  #define USART_CSRA UCSR1A // Control and Status Register A
+  #define USART_CSRB UCSR1B // Control and Status Register B
+  #define USART_DR   UDR1   // Data Register
+
+  #define USART_BIT_DRE   UDRE1  // Data Register Empty
+  #define USART_BIT_DRIE  UDRIE1 // Data Register Empty Interrupt Enable
+  #define USART_BIT_PE    UPE1   // Parity Error
+  #define USART_BIT_RXCIE RXCIE1 // Receive Complete Interrupt Enable
+  #define USART_BIT_RXEN  RXEN1  // Receive Enable
+  #define USART_BIT_TXC   TXC1   // Transmit Complete
+  #define USART_BIT_TXEN  TXEN1  // Transmit Enable
+  #define USART_BIT_U2X   U2X1   // Double Speed Operation
+
+  #define USART_RX_VECT USART1_RX_vect
+  #define USART_TX_VECT USART1_UDRE_vect
+
 #else
+  const uint16_t pin_map[][0] PROGMEM = {{}};
+
   #error No supported platform found
   #error Please file a bug at https://github.com/jbrazio/ardufocus/issues
 #endif

--- a/ardufocus/io.h
+++ b/ardufocus/io.h
@@ -41,9 +41,9 @@ class IO
 
   public:
     static inline void set_as_input(const uint8_t &pin) {
-      const uint8_t     mask = pgm_read_word(&pin_map[pin][HALPIN]);
-      volatile uint8_t *mode = (volatile uint8_t *)(pgm_read_word(&pin_map[pin][HALDIR]));
-      volatile uint8_t *port = (volatile uint8_t *)(pgm_read_word(&pin_map[pin][HALOUT]));
+      const uint8_t     mask = hal_tbl_lookup(pin, IO_BIT);
+      volatile uint8_t *mode = (volatile uint8_t *)(hal_tbl_lookup(pin, IO_DIR));
+      volatile uint8_t *port = (volatile uint8_t *)(hal_tbl_lookup(pin, IO_DATA));
 
       ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
         *mode &= ~mask;
@@ -52,8 +52,8 @@ class IO
     }
 
     static inline void set_as_output(const uint8_t &pin) {
-      const uint8_t     mask = pgm_read_word(&pin_map[pin][HALPIN]);
-      volatile uint8_t *mode = (volatile uint8_t *)(pgm_read_word(&pin_map[pin][HALDIR]));
+      const uint8_t     mask = hal_tbl_lookup(pin, IO_BIT);
+      volatile uint8_t *mode = (volatile uint8_t *)(hal_tbl_lookup(pin, IO_DIR));
 
       ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
         *mode |= mask;
@@ -61,8 +61,8 @@ class IO
     }
 
     static inline void write(const uint8_t &pin, const uint8_t &value) {
-      const uint8_t     mask = pgm_read_word(&pin_map[pin][HALPIN]);
-      volatile uint8_t *port = (volatile uint8_t *)( pgm_read_word(&pin_map[pin][HALOUT]) );
+      const uint8_t     mask = hal_tbl_lookup(pin, IO_BIT);
+      volatile uint8_t *port = (volatile uint8_t *)(hal_tbl_lookup(pin, IO_DATA));
 
       ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
         if(value == LOW) { *port &= ~mask; }
@@ -71,8 +71,8 @@ class IO
     }
 
     static inline uint8_t read(const uint8_t &pin) {
-        const uint8_t     mask  = pgm_read_word(&pin_map[pin][HALPIN]);
-        volatile uint8_t *port  = (volatile uint8_t *)(pgm_read_word(&pin_map[pin][HALIN]));
+        const uint8_t     mask  = hal_tbl_lookup(pin, IO_BIT);
+        volatile uint8_t *port  = (volatile uint8_t *)(hal_tbl_lookup(pin, IO_IN));
 
         if (*port & mask) return HIGH;
         return LOW;

--- a/ardufocus/macro.h
+++ b/ardufocus/macro.h
@@ -20,26 +20,11 @@
 #ifndef __MACRO_H__
 #define __MACRO_H__
 
-//#include <avr/interrupt.h>
-//#include <avr/sfr_defs.h>
-
-//#undef CRITICAL_SECTION_START
-//#define CRITICAL_SECTION_START const uint8_t __SREG___ = SREG; cli();
-
-//#undef CRITICAL_SECTION_END
-//#define CRITICAL_SECTION_END   SREG = __SREG___;
-
 #undef NULL
 #define NULL 0
 
 #undef bit
 #define bit(b) (1UL << (b))
-
-//#undef cbi
-//#define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
-
-//#undef sbi
-//#define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
 
 #undef constrain
 #define constrain(n, l, h) ((n)<(l)?(l):((n)>(h)?(h):(n)))
@@ -51,8 +36,8 @@
 #define asizeof(a) (sizeof(a) / sizeof(*a))
 
 #define force_inline __attribute__((always_inline)) inline
-//#define silence      __attribute__((unused))
+#define silence      __attribute__((unused))
 #define speed        __attribute__((optimize("O3")))
-//#define diet         __attribute__((optimize("Os")))
+#define diet         __attribute__((optimize("Os")))
 
 #endif


### PR DESCRIPTION
This changeset adds the HAL for the ATmega32U4 as described at:
https://cdn.sparkfun.com/datasheets/Dev/Arduino/Boards/ProMicro16MHzv1.pdf