### PR TITLE
Add support for LM335 temperature sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .pioenvs
 .piolibdeps
 ardufocus/localcfg.h
+.pio/
+.vscode/

--- a/ardufocus/analog.cpp
+++ b/ardufocus/analog.cpp
@@ -83,8 +83,18 @@ void Analog::read_async(const uint8_t& channel)
     Analog::s_buffer.n = 0;
     Analog::s_buffer.chan = channel;
 
-    // select the internal 1.1V aref and the target analog channel
-    ADMUX = bit (REFS1) | bit (REFS0) | (channel & 0x07);
+    // select the target analog channel
+    volatile uint8_t admux = channel & 0x07;
+    // now select the correct reference voltage
+  #ifdef TEMP_USE_LM335
+    // 5V reference for LM335
+    admux |= bit (REFS0);
+  #else
+    // 1.1V reference for the default NTC resistor
+    admux |= bit (REFS1) | bit (REFS0)
+  #endif
+    // write admux value
+    ADMUX = admux;
 
     // start the async analog read
     ADCSRA |= bit(ADSC) | bit(ADIE);

--- a/ardufocus/api.h
+++ b/ardufocus/api.h
@@ -58,7 +58,11 @@ class api {
       update_temperature();
       #endif
 
+      #ifdef TEMP_USE_LM335
+      return util::lm335(Analog::read(NTC_ADC_CHANNEL));
+      #else
       return util::steinhart(Analog::read(NTC_ADC_CHANNEL));
+      #endif
     }
 
     static void motor_start(const motor_t& idx) {

--- a/ardufocus/config.h
+++ b/ardufocus/config.h
@@ -179,6 +179,10 @@
 // ----------------------------------------------------------------------------
 // TEMPERATURE SENSOR ---------------------------------------------------------
 // ----------------------------------------------------------------------------
+
+// Uncomment to use LM335 for reading temperature
+//#define TEMP_USE_LM335
+
 #define NTC_ADC_CHANNEL          0
 #define NTC_NOMINAL_TEMP      25.0F
 #define NTC_BCOEFFICIENT    3950.0F

--- a/ardufocus/utility.cpp
+++ b/ardufocus/utility.cpp
@@ -40,6 +40,20 @@ float util::steinhart(const uint16_t& raw)
   return steinhart;
 }
 
+/**
+ * @brief Converts raw ADC data to degrees C
+ * @details Used for LM335
+ *
+ */
+float util::lm335(const uint16_t& raw)
+{
+  float value = constrain(raw, 1, 1022);  // adu
+  value = value * 5000.0f / 1024.0f;      // mV
+  value = value / 10.0f;                  // deg K
+  value = value - 273.15f;                // deg C
+  return value;
+}
+
 #ifdef HAS_ACCELERATION
   /**
    * @brief Linear interpolation function

--- a/ardufocus/utility.h
+++ b/ardufocus/utility.h
@@ -32,6 +32,7 @@ extern volatile uint32_t timer0_compa_count;
 namespace util
 {
   float steinhart(const uint16_t&);
+  float lm335(const uint16_t&);
 
   inline uint16_t  hex2l(const char* str) { return ( strtol(str, NULL, 16)); }
   inline uint32_t hex2ul(const char* str) { return (strtoul(str, NULL, 16)); }


### PR DESCRIPTION
- Added new define TEMP_USE_LM335 to config.h
- Changes when this define is active:
  - ADC reference voltage set to 5.0V
  - A new util function is used to convert to deg C