### PR TITLE
Added speed and stepper mode saving to EEPROM

### DIFF
--- a/ardufocus/ardufocus.cpp
+++ b/ardufocus/ardufocus.cpp
@@ -141,6 +141,7 @@ int main(void)
     g_motor1->set_max_speed(MOTOR1_MAX_SPEED);
     g_motor1->set_min_speed(MOTOR1_MIN_SPEED);
     g_motor1->init();
+    if (g_config.speed_m1 != 0) { g_motor1->set_speed(g_config.speed_m1); }
   #endif
 
   #ifdef MOTOR2_HAS_DRIVER
@@ -150,6 +151,7 @@ int main(void)
     g_motor2->set_max_speed(MOTOR2_MAX_SPEED);
     g_motor2->set_min_speed(MOTOR2_MIN_SPEED);
     g_motor2->init();
+    if (g_config.speed_m2 != 0) { g_motor2->set_speed(g_config.speed_m2); }
   #endif
 
 

--- a/ardufocus/ardufocus.cpp
+++ b/ardufocus/ardufocus.cpp
@@ -142,6 +142,7 @@ int main(void)
     g_motor1->set_min_speed(MOTOR1_MIN_SPEED);
     g_motor1->init();
     if (g_config.speed_m1 != 0) { g_motor1->set_speed(g_config.speed_m1); }
+    if (g_config.half_step_m1) { g_motor1->set_half_step(); }
   #endif
 
   #ifdef MOTOR2_HAS_DRIVER
@@ -152,6 +153,7 @@ int main(void)
     g_motor2->set_min_speed(MOTOR2_MIN_SPEED);
     g_motor2->init();
     if (g_config.speed_m2 != 0) { g_motor2->set_speed(g_config.speed_m2); }
+    if (g_config.half_step_m2) { g_motor2->set_half_step(); }
   #endif
 
 

--- a/ardufocus/eeprom.h
+++ b/ardufocus/eeprom.h
@@ -36,6 +36,8 @@ struct eeprom_map_t {
   uint32_t position_m1; // 02
   uint32_t position_m2; // 06
   bool     dtr_reset;   // 10
+  uint16_t speed_m1;
+  uint16_t speed_m2;
 };
 
 extern eeprom_map_t g_config;

--- a/ardufocus/eeprom.h
+++ b/ardufocus/eeprom.h
@@ -38,6 +38,8 @@ struct eeprom_map_t {
   bool     dtr_reset;   // 10
   uint16_t speed_m1;
   uint16_t speed_m2;
+  bool     half_step_m1;
+  bool     half_step_m2;
 };
 
 extern eeprom_map_t g_config;

--- a/ardufocus/isr.cpp
+++ b/ardufocus/isr.cpp
@@ -50,6 +50,7 @@ ISR(TIMER0_COMPA_vect)
     if(cstate1 != pstate1) {
       if(cstate1 == false) {
         g_config.position_m1 = g_motor1->get_current_position();
+        g_config.speed_m1 = g_motor1->get_speed();
         eeprom_save(&g_config);
       }
       pstate1 = cstate1;
@@ -80,6 +81,7 @@ ISR(TIMER0_COMPA_vect)
     if(cstate2 != pstate2) {
       if(cstate2 == false) {
         g_config.position_m2 = g_motor2->get_current_position();
+        g_config.speed_m2 = g_motor2->get_speed();
         eeprom_save(&g_config);
       }
       pstate2 = cstate2;

--- a/ardufocus/isr.cpp
+++ b/ardufocus/isr.cpp
@@ -51,6 +51,7 @@ ISR(TIMER0_COMPA_vect)
       if(cstate1 == false) {
         g_config.position_m1 = g_motor1->get_current_position();
         g_config.speed_m1 = g_motor1->get_speed();
+        g_config.half_step_m1 = (g_motor1->get_step_mode() == 0xFF);
         eeprom_save(&g_config);
       }
       pstate1 = cstate1;
@@ -82,6 +83,7 @@ ISR(TIMER0_COMPA_vect)
       if(cstate2 == false) {
         g_config.position_m2 = g_motor2->get_current_position();
         g_config.speed_m2 = g_motor2->get_speed();
+        g_config.half_step_m2 = (g_motor2->get_step_mode() == 0xFF);
         eeprom_save(&g_config);
       }
       pstate2 = cstate2;


### PR DESCRIPTION
Hi, moonlite ascom driver will set speed and step mode only on connecting, but sometimes device will reset itself (power issues, cable problems, etc), and initiates full speed... It is anoying, so I added restoring last speed and step mode on init.

It is also handy for me when I operate without connecting to PC sometimes - device remembers last settings from PC driver.